### PR TITLE
fix: align #[cfg] guards for optional features; add default-features …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
-  check:
-    name: cargo check (${{ matrix.os }})
+  check-full:
+    name: cargo check (full features) (${{ matrix.os }})
     needs: fmt
     strategy:
       matrix:
@@ -37,6 +37,20 @@ jobs:
         run: cargo check --features "backend-wgpu,backend-tiny-skia,backend-tiny-skia-x11,backend-tiny-skia-wayland,lyon,display,display-advanced,text-cosmic,i18n,a11y-platform,file-dialog,clipboard,system-theme,global-hotkey,tracing,devtools,file-logging,ext-jiff,ext-image,ext-svg,ext-audio,ssr,async-tokio"
       - if: runner.os != 'Linux'
         run: cargo check --features "backend-wgpu,backend-tiny-skia,backend-tiny-skia-x11,backend-tiny-skia-wayland,lyon,display,display-advanced,text-cosmic,i18n,tray,a11y-platform,file-dialog,clipboard,system-theme,global-hotkey,tracing,devtools,file-logging,ext-jiff,ext-image,ext-svg,ext-audio,ssr,async-tokio"
+
+  check:
+    name: cargo check (default) (${{ matrix.os }})
+    needs: fmt
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libx11-dev libxi-dev libxrandr-dev libwayland-dev libdbus-1-dev libasound2-dev
+      - run: cargo check
 
   clippy:
     name: cargo clippy
@@ -72,7 +86,7 @@ jobs:
     needs: fmt
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -110,9 +110,11 @@ impl UiError {
                 ErrorSeverity::Recoverable
             }
             Self::CallbackPanic { .. } => ErrorSeverity::Recoverable,
-            Self::Image(_) | Self::Svg(_) | Self::FontLoad(_) | Self::GridLayout(_) => {
-                ErrorSeverity::Warning
-            }
+            #[cfg(feature = "ext-image")]
+            Self::Image(_) => ErrorSeverity::Warning,
+            #[cfg(feature = "ext-svg")]
+            Self::Svg(_) => ErrorSeverity::Warning,
+            Self::FontLoad(_) | Self::GridLayout(_) => ErrorSeverity::Warning,
             #[cfg(feature = "ext-audio")]
             Self::Audio(_) => ErrorSeverity::Warning,
             #[cfg(feature = "clipboard")]

--- a/src/platform/a11y_bridge.rs
+++ b/src/platform/a11y_bridge.rs
@@ -356,7 +356,7 @@ impl A11yBridge {
                     events.raise();
                 }
             }
-            #[cfg(target_os = "macos")]
+            #[cfg(all(target_os = "macos", feature = "a11y-platform"))]
             Some(PlatformAdapter::MacOS { adapter }) => {
                 let tree = updater();
                 let _ = self.snapshot.lock().map(|mut s| *s = Some(tree.clone()));

--- a/src/widgets/bundle/scroll.rs
+++ b/src/widgets/bundle/scroll.rs
@@ -493,6 +493,25 @@ pub(crate) fn try_set_offset(
     false
 }
 
+/// Replace the scroll physics policy for a scrollable element at runtime.
+///
+/// Useful for tests that need deterministic boundary behaviour regardless of
+/// platform defaults (e.g. `ClampPhysics` instead of macOS `BouncePhysics`).
+/// Returns true if the element has a ScrollBundle and the physics was set.
+pub fn set_scroll_physics(
+    arena: &crate::core::element::ElementArena,
+    eid: ElementId,
+    physics: Box<dyn crate::physics::ScrollPhysics>,
+) -> bool {
+    if let Some(el) = arena.get(eid) {
+        if let Some(refcell) = el.get_user_data::<ScrollBundleRef>() {
+            refcell.0.set_physics(physics);
+            return true;
+        }
+    }
+    false
+}
+
 /// Try to scroll a scrollable element using its ScrollBundle physics.
 /// Returns `Some((unconsumed_x, unconsumed_y))` if the element has a
 /// ScrollBundle and the scroll was applied. The unconsumed delta is the

--- a/tests/nested_scroll.rs
+++ b/tests/nested_scroll.rs
@@ -11,6 +11,7 @@ use burin::core::context::MountContext;
 use burin::core::dirty_registry;
 use burin::core::widget::Widget;
 use burin::core::ElementId;
+use burin::physics::ClampPhysics;
 use burin::style::Dimension;
 use burin::testing::TestHarness;
 use burin::widgets::bundle::scroll;
@@ -44,6 +45,17 @@ fn scroll_offset_of(h: &TestHarness, eid: ElementId) -> burin::style::Vec2 {
         .comp_scroll(eid)
         .map(|sc| sc.scroll_offset.get())
         .unwrap_or(burin::style::Vec2::ZERO)
+}
+
+/// Swap a scroll element's physics to ClampPhysics for deterministic
+/// boundary behaviour in tests, regardless of platform default
+/// (BouncePhysics on macOS would allow overscroll and consume all delta).
+fn use_clamp_physics(h: &TestHarness, eid: ElementId) {
+    assert!(
+        scroll::set_scroll_physics(&h.arena, eid, Box::new(ClampPhysics)),
+        "element {:?} has no ScrollBundle",
+        eid
+    );
 }
 
 fn scroll_direct(h: &TestHarness, eid: ElementId, dx: f32, dy: f32) -> (f32, f32) {
@@ -93,6 +105,7 @@ fn scroll_by_unconsumed_at_boundary() {
     let mut h = TestHarness::new(400.0, 200.0);
     let id = h.mount(ScrollView::new().child(SizedBox::new().height(200.0)));
     h.run_frame();
+    use_clamp_physics(&h, id);
     // Scroll up past top — physics rejects all
     let (_, uy) = scroll_direct(&h, id, 0.0, -50.0);
     assert!(uy < -40.0, "unconsumed y={:.1} should be ~ -50", uy);
@@ -146,6 +159,10 @@ fn setup_nested(h: &mut TestHarness) -> (ElementId, ElementId) {
 fn nested_inner_at_boundary_passes_unconsumed_to_outer() {
     let mut h = TestHarness::new(400.0, 400.0);
     let (outer_id, inner_id) = setup_nested(&mut h);
+
+    // Use ClampPhysics so unconsumed delta isn't swallowed by bounce overscroll.
+    use_clamp_physics(&h, inner_id);
+    use_clamp_physics(&h, outer_id);
 
     // Scroll inner to max (content 450, vp 150, max=300)
     h.scroll(inner_id, 0.0, -300.0);


### PR DESCRIPTION
…CI check

- a11y_bridge.rs: MacOS match arm now requires a11y-platform feature (fixes #7) - error.rs: Image/Svg severity arms now gated on ext-image/ext-svg - CI: add check job for default features, rename existing to check-full